### PR TITLE
2일차 BFS - 호두

### DIFF
--- a/hodu/src/main/kotlin/main.kt
+++ b/hodu/src/main/kotlin/main.kt
@@ -1,6 +1,5 @@
 import datastructure.*
-import solve.boj.Boj1715Solution
-import solve.boj.Boj2075Solution
+import solve.boj.boj1715.Boj1715Solution
 
 fun main() {
     println("hello walnut")

--- a/hodu/src/main/kotlin/solve/boj/boj1138/Boj1138Solution.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj1138/Boj1138Solution.kt
@@ -1,4 +1,4 @@
-package solve.boj
+package solve.boj.boj1138
 
 // 사람들은 자기보다 큰 사람이 왼쪽에 몇 명 있었는지만을 기억
 // N명의 사람이 있고, 사람들의 키는 1부터 N까지 모두 다르다.

--- a/hodu/src/main/kotlin/solve/boj/boj1715/Boj1715Solution.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj1715/Boj1715Solution.kt
@@ -1,4 +1,4 @@
-package solve.boj
+package solve.boj.boj1715
 
 import datastructure.MinHeap2
 

--- a/hodu/src/main/kotlin/solve/boj/boj1743/1743.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj1743/1743.kt
@@ -3,30 +3,65 @@ package solve.boj.boj1743
 // 백준 1743 - [실버1] 음식물 피하기
 // https://www.acmicpc.net/problem/1743
 
-// 오늘 안에 풀기!
+// 오늘 안에 풀기! = 해결!
+/*
+* 메모리 초과 원인
+* 1. bfs 함수를 실행할 때마다 queue를 새로 생성함. -> 메모리를 쓸데없이 잡아먹음
+* 2. visited를 true로 설정하는 로직의 위치: 실제로 방문하기 전 큐에 넣을 때 true로 설정해도 괜찮음
+*    -> 방문한 노드를 큐에 중복해서 넣는 불상사 방지 가능
+* */
 fun main() {
-    val (n, m, k) = readln().split(" ")?.map{it.toInt()} ?: return
+    val br = System.`in`.bufferedReader()
+    val (n, m, k) = br.readLine()?.split(" ")?.map{it.toInt()} ?: return
     // 음식물o: 1, 음식물x: 0
     val passage = Array(n){Array(m){-1}}
     repeat(k) {
-        val (r, c) = readln().split(" ")?.map{it.toInt()} ?: return
-        passage[r-1][c-1] = 1
+        val (r, c) = br.readLine()?.split(" ")?.map{it.toInt()} ?: return
+        passage[r-1][c-1] = 0
     }
+    br.close()
 
     val answer = lookPassage(n, m, passage)
-    println(answer)
+    val bw = System.out.bufferedWriter()
+    bw.write(answer.toString())
+    bw.close()
 }
 
 fun lookPassage(n: Int, m: Int, passage: Array<Array<Int>>): Int {
+    // dx: 상하
+    // dy: 좌우
+    val dx: Array<Int> = arrayOf(-1, 1, 0, 0)
+    val dy: Array<Int> = arrayOf(0, 0, -1, 1)
+    val visited = Array(n){Array(m){false}}
+    val queue = ArrayDeque<Array<Int>>()
     var answer = 0
-
-    // 0,0 부터 n-1,m-1 까지 모두 순회
-    for(x in 0 ..< n) {
-        for(y in 0 ..< m) {
-            // 음식물이 아니라면 넘어감
-            if(passage[x][y] == -1) continue
+    var foodSize: Int
+    for(startX in 0 ..< n) {
+        for(startY in 0 ..< m) {
+            // 음식물이 아니거나, 이미 화인한 음식물이라면 넘어감
+            if(passage[startX][startY] == -1 || visited[startX][startY]) continue
             // 만약 음식물을 발견한다면 bfs 순회하여 크기 알아내기
-            val foodSize = bfs(x, y, passage, n, m)
+            queue.addLast(arrayOf(startX, startY))
+            visited[startX][startY] = true
+            foodSize = 0
+            while(queue.isNotEmpty()) {
+                val foodXY = queue.removeFirst()
+                val x = foodXY[0]
+                val y = foodXY[1]
+                foodSize++
+                for (i in dx.indices) {
+                    val nx = x + dx[i]
+                    val ny = y + dy[i]
+                    // 범위를 벗어나면 넘어감
+                    if (nx < 0 || nx >= n || ny < 0 || ny >= m) continue
+                    // 음식물이 아니거나 이미 확인한 음식물이라면 넘어감
+                    if (passage[nx][ny] == -1 || visited[nx][ny]) continue
+                    // 새로 확인할 음식물을 큐에 저장
+                    queue.addLast(arrayOf(nx, ny))
+                    // 큐에 넣었으니, 미리 방문 완료 처리
+                    visited[nx][ny] = true
+                }
+            }
             // 발견한 음식물 사이즈가 지금까지 중 제일 크다면 answer로 변경
             if (foodSize > answer) answer = foodSize
         }
@@ -34,28 +69,30 @@ fun lookPassage(n: Int, m: Int, passage: Array<Array<Int>>): Int {
     return answer
 }
 
-fun bfs(startX: Int, startY: Int, passage: Array<Array<Int>>, n: Int, m: Int): Int {
-    // dx: 상하
-    // dy: 좌우
-    val dx = arrayOf(-1, 1, 0, 0)
-    val dy = arrayOf(0, 0, -1, 1)
-    val queue = ArrayDeque<Array<Int>>()
-    var foodSize = 0
-    queue.addLast(arrayOf(startX, startY))
-    while(queue.isNotEmpty()) {
-        val food = queue.removeFirst()
-        val x = food[0]
-        val y = food[1]
-        foodSize++
-        passage[x][y] = foodSize
-        for (i in dx.indices) {
-            val nx = x + dx[i]
-            val ny = y + dy[i]
-            if (nx < 0 || nx >= n || ny < 0 || ny >= m) continue
-            if (passage[nx][ny] == -1 || passage[nx][ny] > 0) continue
-            passage[nx][ny] = foodSize
-            queue.addLast(arrayOf(nx, ny))
-        }
-    }
-    return foodSize
-}
+//fun bfs(startX: Int, startY: Int, passage: Array<Array<Int>>, n: Int, m: Int): Int {
+//    // dx: 상하
+//    // dy: 좌우
+//    val dx: Array<Int> = arrayOf(-1, 1, 0, 0)
+//    val dy: Array<Int> = arrayOf(0, 0, -1, 1)
+//    val queue = ArrayDeque<Array<Int>>()
+//    var foodSize = 0
+//    queue.addLast(arrayOf(startX, startY))
+//    while(queue.isNotEmpty()) {
+//        val foodXY = queue.removeFirst()
+//        val x = foodXY[0]
+//        val y = foodXY[1]
+//        foodSize++
+//        passage[x][y] = foodSize
+//        for (i in dx.indices) {
+//            val nx = x + dx[i]
+//            val ny = y + dy[i]
+//            // 범위를 벗어나면 넘어감
+//            if (nx < 0 || nx >= n || ny < 0 || ny >= m) continue
+//            // 음식물이 아니거나 이미 확인한 음식물이라면 넘어감
+//            if (passage[nx][ny] == -1 || passage[nx][ny] > 0) continue
+//            // 새로 확인할 음식물을 큐에 저장
+//            queue.addLast(arrayOf(nx, ny))
+//        }
+//    }
+//    return foodSize
+//}

--- a/hodu/src/main/kotlin/solve/boj/boj1743/1743.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj1743/1743.kt
@@ -1,0 +1,61 @@
+package solve.boj.boj1743
+
+// 백준 1743 - [실버1] 음식물 피하기
+// https://www.acmicpc.net/problem/1743
+
+// 오늘 안에 풀기!
+fun main() {
+    val (n, m, k) = readln().split(" ")?.map{it.toInt()} ?: return
+    // 음식물o: 1, 음식물x: 0
+    val passage = Array(n){Array(m){-1}}
+    repeat(k) {
+        val (r, c) = readln().split(" ")?.map{it.toInt()} ?: return
+        passage[r-1][c-1] = 1
+    }
+
+    val answer = lookPassage(n, m, passage)
+    println(answer)
+}
+
+fun lookPassage(n: Int, m: Int, passage: Array<Array<Int>>): Int {
+    var answer = 0
+
+    // 0,0 부터 n-1,m-1 까지 모두 순회
+    for(x in 0 ..< n) {
+        for(y in 0 ..< m) {
+            // 음식물이 아니라면 넘어감
+            if(passage[x][y] == -1) continue
+            // 만약 음식물을 발견한다면 bfs 순회하여 크기 알아내기
+            val foodSize = bfs(x, y, passage, n, m)
+            // 발견한 음식물 사이즈가 지금까지 중 제일 크다면 answer로 변경
+            if (foodSize > answer) answer = foodSize
+        }
+    }
+    return answer
+}
+
+fun bfs(startX: Int, startY: Int, passage: Array<Array<Int>>, n: Int, m: Int): Int {
+    // dx: 상하
+    // dy: 좌우
+    val dx = arrayOf(-1, 1, 0, 0)
+    val dy = arrayOf(0, 0, -1, 1)
+    val queue = ArrayDeque<Array<Int>>()
+    var foodSize = 0
+    queue.addLast(arrayOf(startX, startY))
+    while(queue.isNotEmpty()) {
+        val food = queue.removeFirst()
+        val x = food[0]
+        val y = food[1]
+        foodSize++
+        passage[x][y] = foodSize
+        for (i in dx.indices) {
+            val nx = x + dx[i]
+            val ny = y + dy[i]
+            if (nx < 0 || nx >= n || ny < 0 || ny >= m) continue
+            if (passage[nx][ny] == -1 || passage[nx][ny] > 0) continue
+            passage[nx][ny] = foodSize
+            queue.addLast(arrayOf(nx, ny))
+        }
+    }
+    return foodSize
+}

--- a/hodu/src/main/kotlin/solve/boj/boj2075/Boj2075Solution.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj2075/Boj2075Solution.kt
@@ -1,7 +1,6 @@
-package solve.boj
+package solve.boj.boj2075
 
 import datastructure.MaxHeap
-import datastructure.MaxHeapUsingMutableList
 
 class Boj2075Solution {
     fun solve() {

--- a/hodu/src/main/kotlin/solve/boj/boj2178/2178.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj2178/2178.kt
@@ -1,0 +1,60 @@
+package solve.boj.boj2178
+
+// 백준 2178 - [실버1] 미로 탐색
+// https://www.acmicpc.net/problem/2178
+
+// 1: 이동 가능
+// 0: 이동 불가
+// (1,1) 출발, (N,M) 도착
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val (n, m) = br.readLine()?.split(" ")?.map{it.toInt()} ?: return
+    val maze: Array<Array<Int>> = Array(n) { Array(m) {0} }
+    repeat(n) {
+        val line = br.readLine() ?: ""
+        for(i in line.indices) {
+            maze[it][i] = line[i].digitToInt()
+        }
+    }
+    br.close()
+
+    val answer = bfs(n-1, m-1, maze, n, m)
+    val bw = System.out.bufferedWriter()
+    bw.write(answer.toString())
+    bw.close()
+}
+
+fun bfs(destX: Int, destY: Int, maze: Array<Array<Int>>, n: Int, m: Int): Int {
+    // dx: 상 하
+    // dy: 좌 우
+    val dx = arrayOf(-1, 1, 0, 0)
+    val dy = arrayOf(0, 0, -1, 1)
+    // 메모리 초과 -> visited와 answerTable을 함께
+    // 방문x : -1, 방문o : 0 초과
+    val answerTable = Array(n) { Array(m) {-1} }
+    val queue = ArrayDeque<Array<Int>>()
+
+    // (0,0) 부터 시작
+    queue.addLast(arrayOf(0,0))
+    answerTable[0][0] = 1
+    while(queue.isNotEmpty()) {
+        val node = queue.removeFirst()
+        val x = node[0]
+        val y = node[1]
+        if(x == destX && y == destY) return answerTable[x][y]
+        for(i in dx.indices) {
+            val newX = x + dx[i]
+            val newY = y + dy[i]
+            // 범위 벗어나면 넘어감
+            if(newX < 0 || newX >= n || newY < 0 || newY >= m) continue
+            // 갈 수 없는 곳이면 넘어감
+            if(maze[newX][newY] == 0) continue
+            // 이미 방문한 곳이면 넘어감
+            if(answerTable[newX][newY] > 0) continue
+            // 큐에 추가
+            queue.addLast(arrayOf(newX, newY))
+            answerTable[newX][newY] = answerTable[x][y] + 1
+        }
+    }
+    return answerTable[destX][destY]
+}

--- a/hodu/src/main/kotlin/solve/boj/boj21918/Boj21918Solution.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj21918/Boj21918Solution.kt
@@ -1,4 +1,4 @@
-package solve.boj
+package solve.boj.boj21918
 
 // 1번 ix : i번째 전구를 x로 변경
 // 2번 lr : l번째부터 r번째까지 전구의 상태를 반대로

--- a/hodu/src/main/kotlin/solve/boj/boj22860/Boj22860Solution.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj22860/Boj22860Solution.kt
@@ -1,4 +1,4 @@
-package solve.boj
+package solve.boj.boj22860
 
 // 파일 이름이 같은 경우는 동일한 파일이다.
 // 한 폴더 안에는 같은 이름의 파일이 두 개 이상 존재할 수 없다.
@@ -11,6 +11,8 @@ package solve.boj
 // 파일의 종류의 개수 : 같은 파일이 여러개 있을 경우 하나로 계산
 // 파일의 총 개수 : 같은 파일이 있더라도 하나로 계산하지 않는다.
 fun main() {
+    System.`in`.bufferedReader()
+    System.out.bufferedWriter()
     val (folderCounts, fileCounts) = readln().split(" ").map{it.toInt()}
     // map을 쓸까?
     val structure = mutableMapOf<String, MutableList<Pair<Int, String>>>().withDefault { mutableListOf() }

--- a/hodu/src/main/kotlin/solve/boj/boj2644/2644.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj2644/2644.kt
@@ -1,0 +1,43 @@
+package solve.boj.boj2644
+
+// 백준 2644 - [실버2] 촌수 계산
+// https://www.acmicpc.net/problem/2644
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val n = br.readLine()?.toInt() ?: return
+    val (first, second) = br.readLine()?.split(" ")?.map{it.toInt()} ?: return
+    val m = br.readLine()?.toInt() ?: return
+
+    val relation: MutableList<MutableList<Int>> = MutableList(n+1) {mutableListOf()}
+    repeat(m) {
+        val ln = br.readLine() ?: return
+        val (x, y) = ln.split(" ").map{it.toInt()}
+        relation[x].add(y)
+        relation[y].add(x)
+    }
+
+    val answer = bfs(first, second, relation)
+    println(answer)
+}
+
+fun bfs(start: Int, dest: Int, relation: MutableList<MutableList<Int>>): Int {
+    val visited: Array<Boolean> = Array(relation.size) {false}
+    val queue: MutableList<Int> = mutableListOf()
+    val counts = MutableList<Int>(relation.size) {-1}
+    visited[start] = true
+    queue.add(start)
+    while(queue.isNotEmpty()) {
+        val node = queue.removeFirst()
+        visited[node] = true
+        counts[node] = counts[node] + 1
+        if (node == dest) return counts[node]
+        for(child in relation[node]) {
+            if(!visited[child]) {
+                queue.add(child)
+                counts[child] = counts[node]
+            }
+        }
+    }
+    return counts[dest]
+}

--- a/hodu/src/main/kotlin/solve/boj/boj9093/Boj9093Solution.kt
+++ b/hodu/src/main/kotlin/solve/boj/boj9093/Boj9093Solution.kt
@@ -1,4 +1,4 @@
-package solve.boj
+package solve.boj.boj9093
 
 class Boj9093Solution {
     private val testCases: List<String> =


### PR DESCRIPTION
# 3.7(금) 2일차 BFS

## 문제 풀이
- [x] 2644번 - 촌수 계산 [0b3d167](https://github.com/WoowAndroid/ko-test-toddlers/pull/6/commits/0b3d167983ade27cda18d74bee6d51b006c87404)
- [x] 2178번 - 미로 탐색 [172c8f7](https://github.com/WoowAndroid/ko-test-toddlers/pull/6/commits/172c8f7982e9c6dd552cfc4217fcdd479dd50e8f)
- [x] 1743번 - 음식물 피하기 [4773b3a](https://github.com/WoowAndroid/ko-test-toddlers/pull/6/commits/4773b3a3cf38b3052d5f6249df2c12631abf3b20)

## 못 풀었던 문제
- 1743번 - 음식물 피하기

### 실패 원인
정답은 나왔지만, 메모리 초과로 계속 실패했다.
- 노드를 방문 처리하는 코드 위치가 틀린 것은 아니지만, 메모리 측면에서 아쉬웠다.
- bfs 메서드를 반복 호출하여, 방문할 노드 큐를 매번 새로 생성했다.

### 해결 방법
- 노드 방문 처리 코드의 위치를 바꾸어, 큐 삽입 횟수를 줄였다.
- bfs 메서드를 제거하고, 내부 로직을 한 단계 위로 옮겼다.
  - 한번 만든 큐를 계속 재사용할 수 있었다.

## 느낀 점
- 큐를 이용해서 풀이할 때 ArrayDeque를 이제는 실수 없이 잘 사용한다.
- 예전에는 미로탐색같은 문제를 특히나 어려워했는데, 지금은 잘 풀 수 있을 것 같다. 이제는 시간, 공간 복잡도를 잘 고민해보자.
- BufferedReader, BufferedWriter를 썼을 때와 안썼을 때를 아직 체감하지는 못했지만, 시간을 크게 줄일 수 있다고 하니 자주 사용해보자.


## 아쉬웠던 점
- 종료 조건, 방문 처리 조건을 언제 두느냐에 따라 메모리 사용량과 걸리는 시간이 달라진다.
  - 노드를 큐에 삽입 후 곧바로 방문처리를 해두면, 이후에 똑같은 노드를 큐에 중복해서 넣는 것을 방지할 수 있다.
  - 큐 삽입 횟수를 줄이고 큐에서 노드를 빼서 확인하는 횟수도 줄어든다.
